### PR TITLE
fixing embedding of local audio and video files

### DIFF
--- a/main.js
+++ b/main.js
@@ -131,8 +131,8 @@ function setContent(content, fileDirectory) {
     );
   };
 
-  // fixing embedding of local images
-  $htmlContent.find("img[src]").each(function() {
+  // fixing embedding of local image, audio and video files
+  $htmlContent.find("img[src], source[src]").each(function() {
     var currentSrc = $(this).attr("src");
     if (!hasURLProtocol(currentSrc)) {
       var path = (isWeb ? "" : "file://") + fileDirectory + "/" + currentSrc;


### PR DESCRIPTION
# Description

This commit fixes the embedding of local audio and video files inside of markdown files, in raw HTML.

Here is an arbitrary _audio_video_test.md_ markdown file to illustrate this:

```
# Local audio and video files test

## Audio

<audio controls>
	<source src="White-eyed_Vireo_VOL_11-15_Dudley_T._Dougherty_Natural_Sounds_Collection.ogg" type="audio/ogg">
	Your browser does not support the audio element.
</audio>

By RobertBenson (Own work) [<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a>], <a href="https://commons.wikimedia.org/wiki/File%3AWhite-eyed_Vireo_VOL_11-15_Dudley_T._Dougherty_Natural_Sounds_Collection.ogg">via Wikimedia Commons</a>

## Video

<video width="400" controls>
	<source src="Two-Horned_Chameleon.webm.480p.ogv" type="video/ogg">
	Your browser does not support HTML5 video.
</video>

By Raoul Kopacka (https://vimeo.com/51630102) [<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>], <a href="https://commons.wikimedia.org/wiki/File%3ATwo-Horned_Chameleon.webm">via Wikimedia Commons</a>
```

Here is the rendering of _audio_video_test.md_ in viewerMD **before** commit 7c39c6c (audio and video files are not working):

![before](https://cloud.githubusercontent.com/assets/19945869/21080147/076a4ab2-bfa8-11e6-8aab-f0595875281c.png)

Here is the rendering of _audio_video_test.md_ in viewerMD **after** commit 7c39c6c (audio and video files are working):

![after](https://cloud.githubusercontent.com/assets/19945869/21080148/0b6249ee-bfa8-11e6-99d4-3c98329cdc07.png)

The _audio_video_test.md_ markdown file and associated audio and video files can be downloaded [here](https://github.com/simonbland/viewerMD/files/644425/audio_video_test.zip).

# Implementation

This fix expands the scope of the original fix for the `src` attribute of the `<img>` elements, by adding support for the `src` attribute of the `<source>` elements also, which are children elements of the `<picture>`, `<audio>` and `<video>` elements. In consequence, this fixes the wrong relative path problem for these elements also.

* [The `<source>` tag on w3schools](http://www.w3schools.com/TAgs/tag_source.asp)
* [The `<source>` tag on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
* [The `<source>` tag on WHATWG](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element)

# Justification

I'm aware that the support of audio and video files in markdown currently varies from specifications and implementations, according to my own experiments and readings. Especially, a standard syntax to add audio and video files is not there yet, as discussed in the [Embedded audio and video](https://talk.commonmark.org/t/embedded-audio-and-video/441) talk regarding the CommonMark specification, which leaves markdown users with only one possibility if they want audio and video files in their markdowns today: embed them in raw HTML.

According to John Gruber, the original markdown author, [raw HTML should be supported in markdown](http://daringfireball.net/projects/markdown/syntax#html):

> For any markup that is not covered by Markdown’s syntax, you simply use HTML itself. There’s no need to preface it or delimit it to indicate that you’re switching from Markdown to HTML; you just use the tags.

Therefore, I firmly believe that the fix in this commit is legitimate and can benefit many TagSpaces users needing support for audio and video files in theirs markdowns, including me.

What do you think about this?